### PR TITLE
Add http:// or https:// if not found

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -6,6 +6,10 @@ const shortenerService = require('../services/shortener');
 router.post('/shortener', (req, res) => {
 	let { originalUrl } = req.body;
 
+	if (!(originalUrl.startsWith("http://")) || originalUrl.startsWith("https://")) {
+		originalUrl = "https://" + originalUrl
+	}
+
 	try {
 		originalUrl = new URL({ toString: () => originalUrl });
 	} catch (err) {


### PR DESCRIPTION
Currently it gives an "Invalid URL" error when a url is entered (without http or https)

So to fix this, in this PR i just added "https://" to the url if it doesn't start with the same.
This will also be checked later on, as usual
![image](https://user-images.githubusercontent.com/63950637/194293338-1da6a22b-b54c-4475-af20-438af27494d7.png)
