### PR TITLE
Fix typo - change "bellow" to "below"

### DIFF
--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -155,7 +155,7 @@ export default component$(() => {
           URL Shortener
         </h1>
         <div class="alert alert-primary" role="alert">
-          Add your very long <b>URL</b> in the input bellow and click on the button to make it shorter
+          Add your very long <b>URL</b> in the input below and click on the button to make it shorter
         </div>
         <div class="input-group mb-3">
           <input type="text" id="urlInput" class="border-primary text-light bg-dark form-control" placeholder="Very long url..." onKeyPress$={(event) => handleShortenerKeypress$(event)} aria-label="url" aria-describedby="shortenerBtn" />


### PR DESCRIPTION
Fixed a typo on line 158 - "below" means underneath, "bellow" means to shout or roar!

"Add your very long URL in the input below and click on the button to make it shorter"