### PR TITLE
Update docs.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,7 +1,7 @@
 name: 📄 Documentation suggestion
 description: Suggestions on how we can improve the documentation.
 title: '[DOCS]'
-labels: [docs, triage]
+labels: [documentation]
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
We don't need triage on documentation at the moment. Also the correct label is 'documentation'