### PR TITLE
Fix href inside of README pointing at the another repositories issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Simply copy and paste a URL into the provided area. Then click shorten URL! Your
 
 Just create a [Pull request](https://github.com/origranot/url-shortener/pulls) already 😃
 
-_See the [open issues](https://github.com/othneildrew/Best-README-Template/issues) for a full list of proposed features (and known issues)._
+_See the [open issues](https://github.com/origranot/url-shortener/issues) for a full list of proposed features (and known issues)._
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 


### PR DESCRIPTION
The readme was pointing at another repositories issue page. Now it correctly redirects to this ones issue page