### PR TITLE
Add small tooltip on top of copy, open in new tab and qr code buttons

### DIFF
--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -90,6 +90,7 @@ export default component$(() => {
               <div id="action" className="hidden btn-group p-4">
                 <button
                   type="button"
+                  title="Copy"
                   className="btn hover:btn-primary"
                   onClick$={() => copyUrl(state)}
                 >
@@ -110,6 +111,7 @@ export default component$(() => {
                 </button>
                 <button
                   type="button"
+                  title="Open in new tab"
                   className="btn hover:btn-primary"
                   onClick$={() => openLink()}
                 >
@@ -130,6 +132,7 @@ export default component$(() => {
                 </button>
                 <button
                   type="button"
+                  title="QR Code"
                   className="btn hover:btn-primary"
                   onClick$={() => generateQRCode(100)}
                 >


### PR DESCRIPTION
I was not able to get a screenshot but it's pretty easy to test it. 
Just keep your mouse on top of each of those buttons for a few seconds and you should be able to see a small "tooltip" with the title.
![image](https://user-images.githubusercontent.com/37005757/195248455-fd74755d-c2b1-4ded-9ab8-d7e59b392ec0.png)
